### PR TITLE
Add authorization header for ApiClients

### DIFF
--- a/oncokbPrivateApiClient/src/main/java/org/oncokb/ApiClient.java
+++ b/oncokbPrivateApiClient/src/main/java/org/oncokb/ApiClient.java
@@ -90,6 +90,7 @@ public class ApiClient {
         initHttpClient();
 
         // Setup authentications (key: authentication name, value: authentication).
+        authentications.put("Authorization", new HttpBearerAuth("bearer"));
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
     }

--- a/oncokbPublicApiClient/src/main/java/org/oncokb/ApiClient.java
+++ b/oncokbPublicApiClient/src/main/java/org/oncokb/ApiClient.java
@@ -90,6 +90,7 @@ public class ApiClient {
         initHttpClient();
 
         // Setup authentications (key: authentication name, value: authentication).
+        authentications.put("Authorization", new HttpBearerAuth("bearer"));
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
     }


### PR DESCRIPTION
Manually setting up the authentications.
Seems like oncokb core api-docs does not have the security definitions, so the generator is not able to automatically add this line of code. 

https://stackoverflow.com/questions/39724076/swagger-codegen-cli-java-client-how-to-use-it-right